### PR TITLE
fix runtime caching for vanilla-sw and workbox

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -7,8 +7,7 @@
 import { RemixBrowser } from "@remix-run/react";
 import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
-import { loadServiceWorker } from "./deprecated/loader";
-import { logger } from "./deprecated/core";
+import { loadServiceWorker } from "~/remix-pwa-sw/react";
 
 startTransition(() => {
   hydrateRoot(

--- a/app/entry.workbox.ts
+++ b/app/entry.workbox.ts
@@ -1,0 +1,108 @@
+/// <reference lib="WebWorker" />
+
+import { registerRoute, setDefaultHandler } from "workbox-routing";
+import { CacheFirst, NetworkFirst } from "workbox-strategies";
+import { BackgroundSyncPlugin } from "workbox-background-sync";
+
+import { 
+  matchAssetRequest, 
+  matchDocumentRequest, 
+  matchLoaderRequest, 
+  remixLoaderPlugin 
+} from '~/remix-pwa-sw/workbox'
+
+import { 
+  handlePush,
+  handleMessage
+} from '~/remix-pwa-sw'
+
+declare let self: ServiceWorkerGlobalScope;
+
+const PAGES = "page-cache-v1";
+const DATA = "data-cache-v1";
+const ASSETS = "assets-cache-v1";
+const StaticAssets = ['/build/', '/icons/']
+
+function debug(...messages: any[]) {
+  if (process.env.NODE_ENV !== "production") {
+    console.debug(...messages);
+  }
+}
+
+// (dev-afzalansari) - TODO: This plugin is just for testing workbox in development
+// remove this plugin while creating a template from it.
+const backgroundSyncPlugin = new BackgroundSyncPlugin("loaderQueue", {
+  maxRetentionTime: 60 * 24,
+  onSync: async ({ queue }) => {
+    let entry;
+    while ((entry = await queue.shiftRequest())) {
+      try {
+        const replayedResponse = await fetch(entry.request.clone());
+        const dataCache = await caches.open(DATA);
+        await dataCache.put(entry.request, replayedResponse.clone());
+
+        debug(
+          `Request for '${entry.request.url}' ` +
+            `has been replayed in queue '${queue.name}'`
+        );
+      } catch (error) {
+        await queue.unshiftRequest(entry);
+
+        debug(
+          `Request for '${entry.request.url}' ` +
+            `failed to replay, putting it back in queue '${queue.name}'`
+        );
+      }
+    }
+    debug(
+      `All requests in queue '${queue.name}' have successfully ` +
+        `replayed; the queue is now empty!`
+    );
+  },
+});
+//////////////////////////////
+
+
+// Assets
+registerRoute((event) => matchAssetRequest(event, StaticAssets),
+  new CacheFirst({
+    cacheName: ASSETS,
+  })
+);
+
+// Loaders
+registerRoute(
+  matchLoaderRequest,
+  new NetworkFirst({
+    cacheName: DATA,
+    plugins: [backgroundSyncPlugin, remixLoaderPlugin],
+  })
+);
+
+// Documents
+registerRoute(
+  matchDocumentRequest,
+  new NetworkFirst({
+    cacheName: PAGES,
+  })
+);
+
+setDefaultHandler(({ request }) => {
+  return fetch(request.clone());
+});
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("push", (event) => {
+  event.waitUntil(handlePush(event));
+});
+
+self.addEventListener("message", (event) => {
+  event.waitUntil(handleMessage(event, { dataCache: DATA, documentCache: PAGES }));
+});

--- a/app/precache.workbox.ts
+++ b/app/precache.workbox.ts
@@ -1,0 +1,286 @@
+/// <reference lib="WebWorker" />
+
+import { json } from "@remix-run/server-runtime";
+import type { AssetsManifest } from "@remix-run/react/dist/entry";
+import type { EntryRoute } from "@remix-run/react/dist/routes";
+
+declare let self: ServiceWorkerGlobalScope;
+
+function debug(...messages: any[]) {
+  if (process.env.NODE_ENV === "development") {
+    console.debug(...messages);
+  }
+}
+
+async function handleInstall(event: ExtendableEvent) {
+  debug("Service worker installed");
+}
+
+async function handleActivate(event: ExtendableEvent) {
+  debug("Service worker activated");
+}
+
+const ASSET_CACHE = "asset-cache";
+const DATA_CACHE = "data-cache";
+const DOCUMENT_CACHE = "document-cache";
+const STATIC_ASSETS = ["/build/", "/icons/"];
+
+async function handleSyncRemixManifest(event: ExtendableMessageEvent) {
+  console.debug("sync manifest");
+  const cachePromises: Map<string, Promise<void>> = new Map();
+  const [dataCache, documentCache, assetCache] = await Promise.all([
+    caches.open(DATA_CACHE),
+    caches.open(DOCUMENT_CACHE),
+    caches.open(ASSET_CACHE),
+  ]);
+  const manifest: AssetsManifest = event.data.manifest;
+  const routes = Object.values(manifest.routes);
+
+  for (const route of routes) {
+    if (route.id.includes("$")) {
+      console.debug("parametrized route", route.id);
+      continue;
+    }
+
+    cacheRoute(route);
+  }
+
+  await Promise.all(cachePromises.values());
+
+  function cacheRoute(route: EntryRoute) {
+    const pathname = getPathname(route);
+    if (route.hasLoader) {
+      cacheLoaderData(route);
+    }
+
+    if (route.module) {
+      cachePromises.set(route.module, cacheAsset(route.module));
+    }
+
+    if (route.imports) {
+      for (const assetUrl of route.imports) {
+        debug(route.index, route.parentId, route.imports, route.module);
+        if (cachePromises.has(assetUrl)) {
+          continue;
+        }
+
+        cachePromises.set(assetUrl, cacheAsset(assetUrl));
+      }
+    }
+
+    cachePromises.set(
+      pathname,
+      documentCache.add(pathname).catch((error) => {
+        console.debug(`Failed to cache document ${pathname}:`, error);
+      })
+    );
+  }
+
+  function cacheLoaderData(route: EntryRoute) {
+    const pathname = getPathname(route);
+    const params = new URLSearchParams({ _data: route.id });
+    const search = `?${params.toString()}`;
+    const url = pathname + search;
+    if (!cachePromises.has(url)) {
+      console.debug("Caching data for", url);
+      cachePromises.set(
+        url,
+        dataCache.add(url).catch((error) => {
+          console.debug(`Failed to cache data for ${url}:`, error);
+        })
+      );
+    }
+  }
+
+  async function cacheAsset(assetUrl: string) {
+    if (await assetCache.match(assetUrl)) {
+      return;
+    }
+
+    console.debug("Caching asset", assetUrl);
+    return assetCache.add(assetUrl).catch((error) => {
+      console.debug(`Failed to cache asset ${assetUrl}:`, error);
+    });
+  }
+
+  function getPathname(route: EntryRoute) {
+    let pathname = "";
+    if (route.path && route.path.length > 0) {
+      pathname = "/" + route.path;
+    }
+    if (route.parentId) {
+      const parentPath = getPathname(manifest.routes[route.parentId]);
+      if (parentPath) {
+        pathname = parentPath + pathname;
+      }
+    }
+    return pathname;
+  }
+}
+
+async function handleFetch(event: FetchEvent): Promise<Response> {
+  const url = new URL(event.request.url);
+
+  if (isAssetRequest(event.request)) {
+    const cached = await caches.match(event.request, {
+      cacheName: ASSET_CACHE,
+      ignoreVary: true,
+      ignoreSearch: true,
+    });
+    if (cached) {
+      debug("Serving asset from cache", url.pathname);
+      return cached;
+    }
+
+    debug("Serving asset from network", url.pathname);
+    const response = await fetch(event.request);
+    if (response.status === 200) {
+      const cache = await caches.open(ASSET_CACHE);
+      await cache.put(event.request, response.clone());
+    }
+    return response;
+  }
+
+  if (isLoaderRequest(event.request)) {
+    try {
+      debug("Serving data from network", url.pathname + url.search);
+      const response = await fetch(event.request.clone());
+      const cache = await caches.open(DATA_CACHE);
+      await cache.put(event.request, response.clone());
+      return response;
+    } catch (error) {
+      debug(
+        "Serving data from network failed, falling back to cache",
+        url.pathname + url.search
+      );
+      const response = await caches.match(event.request);
+      if (response) {
+        response.headers.set("X-Remix-Worker", "yes");
+        return response;
+      }
+
+      return json(
+        { message: "Network Error" },
+        {
+          status: 500,
+          headers: { "X-Remix-Catch": "yes", "X-Remix-Worker": "yes" },
+        }
+      );
+    }
+  }
+
+  if (isDocumentGetRequest(event.request)) {
+    const url = new URL(event.request.url);
+    console.debug("Serving document from network", url.pathname);
+    return caches.open(DOCUMENT_CACHE).then((cache) =>
+      fetch(event.request.clone())
+        .then((response) => {
+          cache.put(event.request, response.clone());
+          return response;
+        })
+        .catch(async (error) => {
+          console.debug(
+            "Serving document from network failed, falling back to cache",
+            url.pathname
+          );
+          const response = await caches.match(event.request);
+          if (!response) {
+            throw error;
+          }
+          return response;
+        })
+    );
+  }
+
+  return fetch(event.request.clone());
+}
+
+const handlePush = (event: PushEvent) => {
+  const data = JSON.parse(event?.data!.text());
+  const title = data.title ? data.title : "Remix PWA";
+
+  const options = {
+    body: data.body ? data.body : "Notification Body Text",
+    icon: data.icon ? data.icon : "/icons/android-icon-192x192.png",
+    badge: data.badge ? data.badge : "/icons/android-icon-48x48.png",
+    dir: data.dir ? data.dir : "auto",
+    image: data.image ? data.image : undefined,
+    silent: data.silent ? data.silent : false,
+  };
+
+  self.registration.showNotification(title, {
+    ...options,
+  });
+};
+
+function isMethod(request: Request, methods: string[]) {
+  return methods.includes(request.method.toLowerCase());
+}
+
+function isAssetRequest(request: Request) {
+  return (
+    isMethod(request, ["get"]) &&
+    STATIC_ASSETS.some((publicPath) => request.url.includes(publicPath))
+  );
+}
+
+function isLoaderRequest(request: Request) {
+  const url = new URL(request.url);
+  return isMethod(request, ["get"]) && url.searchParams.get("_data");
+}
+
+function isDocumentGetRequest(request: Request) {
+  return isMethod(request, ["get"]) && request.mode === "navigate";
+}
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(handleInstall(event).then(() => self.skipWaiting()));
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(handleActivate(event).then(() => self.clients.claim()));
+});
+
+self.addEventListener("message", (event) => {
+  // event.waitUntil(handleMessage(event));
+  event.waitUntil(handleSyncRemixManifest(event));
+});
+
+self.addEventListener("push", (event) => {
+  // self.clients.matchAll().then(function (c) {
+  // if (c.length === 0) {
+  event.waitUntil(handlePush(event));
+  // } else {
+  //   console.log("Application is already open!");
+  // }
+  // });
+});
+
+self.addEventListener("fetch", (event) => {
+  event.respondWith(
+    (async () => {
+      const result = {} as
+        | { error: unknown; response: Response }
+        | { error: undefined; response: Response };
+      try {
+        result.response = await handleFetch(event);
+      } catch (error) {
+        result.error = error;
+      }
+
+      return appHandleFetch(event, result);
+    })()
+  );
+});
+
+async function appHandleFetch(
+  event: FetchEvent,
+  {
+    error,
+    response,
+  }:
+    | { error: unknown; response: Response }
+    | { error: undefined; response: Response }
+): Promise<Response> {
+  return response;
+}

--- a/app/precache.worker.ts
+++ b/app/precache.worker.ts
@@ -1,0 +1,287 @@
+/// <reference lib="WebWorker" />
+
+import { json } from "@remix-run/server-runtime";
+import type { AssetsManifest } from "@remix-run/react/dist/entry";
+import type { EntryRoute } from "@remix-run/react/dist/routes";
+
+export type {};
+declare let self: ServiceWorkerGlobalScope;
+
+function debug(...messages: any[]) {
+  if (process.env.NODE_ENV === "development") {
+    console.debug(...messages);
+  }
+}
+
+async function handleInstall(event: ExtendableEvent) {
+  debug("Service worker installed");
+}
+
+async function handleActivate(event: ExtendableEvent) {
+  debug("Service worker activated");
+}
+
+const ASSET_CACHE = "asset-cache";
+const DATA_CACHE = "data-cache";
+const DOCUMENT_CACHE = "document-cache";
+const STATIC_ASSETS = ["/build/", "/icons/"];
+
+async function handleSyncRemixManifest(event: ExtendableMessageEvent) {
+  console.debug("sync manifest");
+  const cachePromises: Map<string, Promise<void>> = new Map();
+  const [dataCache, documentCache, assetCache] = await Promise.all([
+    caches.open(DATA_CACHE),
+    caches.open(DOCUMENT_CACHE),
+    caches.open(ASSET_CACHE),
+  ]);
+  const manifest: AssetsManifest = event.data.manifest;
+  const routes = Object.values(manifest.routes);
+
+  for (const route of routes) {
+    if (route.id.includes("$")) {
+      console.debug("parametrized route", route.id);
+      continue;
+    }
+
+    cacheRoute(route);
+  }
+
+  await Promise.all(cachePromises.values());
+
+  function cacheRoute(route: EntryRoute) {
+    const pathname = getPathname(route);
+    if (route.hasLoader) {
+      cacheLoaderData(route);
+    }
+
+    if (route.module) {
+      cachePromises.set(route.module, cacheAsset(route.module));
+    }
+
+    if (route.imports) {
+      for (const assetUrl of route.imports) {
+        debug(route.index, route.parentId, route.imports, route.module);
+        if (cachePromises.has(assetUrl)) {
+          continue;
+        }
+
+        cachePromises.set(assetUrl, cacheAsset(assetUrl));
+      }
+    }
+
+    cachePromises.set(
+      pathname,
+      documentCache.add(pathname).catch((error) => {
+        console.debug(`Failed to cache document ${pathname}:`, error);
+      })
+    );
+  }
+
+  function cacheLoaderData(route: EntryRoute) {
+    const pathname = getPathname(route);
+    const params = new URLSearchParams({ _data: route.id });
+    const search = `?${params.toString()}`;
+    const url = pathname + search;
+    if (!cachePromises.has(url)) {
+      console.debug("Caching data for", url);
+      cachePromises.set(
+        url,
+        dataCache.add(url).catch((error) => {
+          console.debug(`Failed to cache data for ${url}:`, error);
+        })
+      );
+    }
+  }
+
+  async function cacheAsset(assetUrl: string) {
+    if (await assetCache.match(assetUrl)) {
+      return;
+    }
+
+    console.debug("Caching asset", assetUrl);
+    return assetCache.add(assetUrl).catch((error) => {
+      console.debug(`Failed to cache asset ${assetUrl}:`, error);
+    });
+  }
+
+  function getPathname(route: EntryRoute) {
+    let pathname = "";
+    if (route.path && route.path.length > 0) {
+      pathname = "/" + route.path;
+    }
+    if (route.parentId) {
+      const parentPath = getPathname(manifest.routes[route.parentId]);
+      if (parentPath) {
+        pathname = parentPath + pathname;
+      }
+    }
+    return pathname;
+  }
+}
+
+async function handleFetch(event: FetchEvent): Promise<Response> {
+  const url = new URL(event.request.url);
+
+  if (isAssetRequest(event.request)) {
+    const cached = await caches.match(event.request, {
+      cacheName: ASSET_CACHE,
+      ignoreVary: true,
+      ignoreSearch: true,
+    });
+    if (cached) {
+      debug("Serving asset from cache", url.pathname);
+      return cached;
+    }
+
+    debug("Serving asset from network", url.pathname);
+    const response = await fetch(event.request);
+    if (response.status === 200) {
+      const cache = await caches.open(ASSET_CACHE);
+      await cache.put(event.request, response.clone());
+    }
+    return response;
+  }
+
+  if (isLoaderRequest(event.request)) {
+    try {
+      debug("Serving data from network", url.pathname + url.search);
+      const response = await fetch(event.request.clone());
+      const cache = await caches.open(DATA_CACHE);
+      await cache.put(event.request, response.clone());
+      return response;
+    } catch (error) {
+      debug(
+        "Serving data from network failed, falling back to cache",
+        url.pathname + url.search
+      );
+      const response = await caches.match(event.request);
+      if (response) {
+        response.headers.set("X-Remix-Worker", "yes");
+        return response;
+      }
+
+      return json(
+        { message: "Network Error" },
+        {
+          status: 500,
+          headers: { "X-Remix-Catch": "yes", "X-Remix-Worker": "yes" },
+        }
+      );
+    }
+  }
+
+  if (isDocumentGetRequest(event.request)) {
+    const url = new URL(event.request.url);
+    console.debug("Serving document from network", url.pathname);
+    return caches.open(DOCUMENT_CACHE).then((cache) =>
+      fetch(event.request.clone())
+        .then((response) => {
+          cache.put(event.request, response.clone());
+          return response;
+        })
+        .catch(async (error) => {
+          console.debug(
+            "Serving document from network failed, falling back to cache",
+            url.pathname
+          );
+          const response = await caches.match(event.request);
+          if (!response) {
+            throw error;
+          }
+          return response;
+        })
+    );
+  }
+
+  return fetch(event.request.clone());
+}
+
+const handlePush = (event: PushEvent) => {
+  const data = JSON.parse(event?.data!.text());
+  const title = data.title ? data.title : "Remix PWA";
+
+  const options = {
+    body: data.body ? data.body : "Notification Body Text",
+    icon: data.icon ? data.icon : "/icons/android-icon-192x192.png",
+    badge: data.badge ? data.badge : "/icons/android-icon-48x48.png",
+    dir: data.dir ? data.dir : "auto",
+    image: data.image ? data.image : undefined,
+    silent: data.silent ? data.silent : false,
+  };
+
+  self.registration.showNotification(title, {
+    ...options,
+  });
+};
+
+function isMethod(request: Request, methods: string[]) {
+  return methods.includes(request.method.toLowerCase());
+}
+
+function isAssetRequest(request: Request) {
+  return (
+    isMethod(request, ["get"]) &&
+    STATIC_ASSETS.some((publicPath) => request.url.includes(publicPath))
+  );
+}
+
+function isLoaderRequest(request: Request) {
+  const url = new URL(request.url);
+  return isMethod(request, ["get"]) && url.searchParams.get("_data");
+}
+
+function isDocumentGetRequest(request: Request) {
+  return isMethod(request, ["get"]) && request.mode === "navigate";
+}
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(handleInstall(event).then(() => self.skipWaiting()));
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(handleActivate(event).then(() => self.clients.claim()));
+});
+
+self.addEventListener("message", (event) => {
+  // event.waitUntil(handleMessage(event));
+  event.waitUntil(handleSyncRemixManifest(event));
+});
+
+self.addEventListener("push", (event) => {
+  // self.clients.matchAll().then(function (c) {
+  // if (c.length === 0) {
+  event.waitUntil(handlePush(event));
+  // } else {
+  //   console.log("Application is already open!");
+  // }
+  // });
+});
+
+self.addEventListener("fetch", (event) => {
+  event.respondWith(
+    (async () => {
+      const result = {} as
+        | { error: unknown; response: Response }
+        | { error: undefined; response: Response };
+      try {
+        result.response = await handleFetch(event);
+      } catch (error) {
+        result.error = error;
+      }
+
+      return appHandleFetch(event, result);
+    })()
+  );
+});
+
+async function appHandleFetch(
+  event: FetchEvent,
+  {
+    error,
+    response,
+  }:
+    | { error: unknown; response: Response }
+    | { error: undefined; response: Response }
+): Promise<Response> {
+  return response;
+}

--- a/app/remix-pwa-sw/core/index.ts
+++ b/app/remix-pwa-sw/core/index.ts
@@ -1,24 +1,23 @@
-export { logger } from './logger'
+export { logger } from "./logger";
+export { handlePush } from "./push";
+export { handleMessage } from "./message";
 
 export function isMethod(request: Request, methods: string[]): boolean {
-    return methods.includes(request.method.toLowerCase());
-  }
-  
-  
-  export function isAssetRequest(request: Request, assetUrls: string[]): boolean {
-    return (
-      isMethod(request, ["get"]) &&
-      assetUrls.some((publicPath) =>
-        request.url.includes(publicPath)
-      )
-    );
-  }
-  
-  export function isDocumentRequest(request: Request): boolean {
-    return isMethod(request, ["get"]) && request.mode === "navigate";
-  }
-  
-  export function isLoaderRequest(request: Request): string | false | null {
-    const url = new URL(request.url);
-    return isMethod(request, ["get"]) && url.searchParams.get("_data");
-  }
+  return methods.includes(request.method.toLowerCase());
+}
+
+export function isAssetRequest(request: Request, assetUrls: string[]): boolean {
+  return (
+    isMethod(request, ["get"]) &&
+    assetUrls.some((publicPath) => request.url.includes(publicPath))
+  );
+}
+
+export function isDocumentRequest(request: Request): boolean {
+  return isMethod(request, ["get"]) && request.mode === "navigate";
+}
+
+export function isLoaderRequest(request: Request): string | false | null {
+  const url = new URL(request.url);
+  return isMethod(request, ["get"]) && url.searchParams.get("_data");
+}

--- a/app/remix-pwa-sw/core/logger.ts
+++ b/app/remix-pwa-sw/core/logger.ts
@@ -11,31 +11,31 @@ declare global {
   interface WorkerGlobalScope {
     /**
      * Disable all logs from displaying in the console.
-     * 
+     *
      * @default false
      */
     __DISABLE_PWA_DEV_LOGS: boolean;
     /**
      * Disable debug logs from displaying in the console.
-     * 
+     *
      * @default false
      */
     __DISABLE_PWA_DEBUG_LOGS: boolean;
     /**
      * Disable info logs from displaying in the console.
-     * 
+     *
      * @default false
      */
     __DISABLE_PWA_INFO_LOGS: boolean;
     /**
      * Disable warning logs from displaying in the console.
-     * 
+     *
      * @default false
      */
     __DISABLE_PWA_WARN_LOGS: boolean;
     /**
      * Disable error logs from displaying in the console.
-     * 
+     *
      * @default false
      */
     __DISABLE_PWA_ERROR_LOGS: boolean;
@@ -44,31 +44,31 @@ declare global {
   interface Window {
     /**
      * Disable all logs from displaying in the console.
-     * 
+     *
      * @default false
      */
     __DISABLE_PWA_DEV_LOGS: boolean;
     /**
      * Disable debug logs from displaying in the console.
-     * 
+     *
      * @default false
      */
     __DISABLE_PWA_DEBUG_LOGS: boolean;
     /**
      * Disable info logs from displaying in the console.
-     * 
+     *
      * @default false
      */
     __DISABLE_PWA_INFO_LOGS: boolean;
     /**
      * Disable warning logs from displaying in the console.
-     * 
+     *
      * @default false
      */
     __DISABLE_PWA_WARN_LOGS: boolean;
     /**
      * Disable error logs from displaying in the console.
-     * 
+     *
      * @default false
      */
     __DISABLE_PWA_ERROR_LOGS: boolean;

--- a/app/remix-pwa-sw/core/message.ts
+++ b/app/remix-pwa-sw/core/message.ts
@@ -1,0 +1,56 @@
+export async function handleMessage(
+  event: ExtendableMessageEvent,
+  {
+    dataCache,
+    documentCache,
+  }: {
+    dataCache: string;
+    documentCache: string;
+  }
+) {
+  const cachePromises: Map<string, Promise<void>> = new Map();
+
+  if (event.data.type === "REMIX_NAVIGATION") {
+    const { isMount, location, matches, manifest } = event.data;
+    const documentUrl = location.pathname + location.search + location.hash;
+
+    const [DataCache, DocumentCache, existingDocument] = await Promise.all([
+      caches.open(dataCache),
+      caches.open(documentCache),
+      caches.match(documentUrl),
+    ]);
+
+    if (!existingDocument || !isMount) {
+      // debug("Caching document for", documentUrl);
+      cachePromises.set(
+        documentUrl,
+        DocumentCache.add(documentUrl).catch((error) => {
+          // debug(`Failed to cache document for ${documentUrl}:`, error);
+        })
+      );
+    }
+
+    if (isMount) {
+      for (const match of matches) {
+        if (manifest.routes[match.id].hasLoader) {
+          const params = new URLSearchParams(location.search);
+          params.set("_data", match.id);
+          let search = params.toString();
+          search = search ? `?${search}` : "";
+          const url = location.pathname + search + location.hash;
+          if (!cachePromises.has(url)) {
+            //   debug("Caching data for", url);
+            cachePromises.set(
+              url,
+              DataCache.add(url).catch((error) => {
+                //   debug(`Failed to cache data for ${url}:`, error);
+              })
+            );
+          }
+        }
+      }
+    }
+  }
+
+  await Promise.all(cachePromises.values());
+}

--- a/app/remix-pwa-sw/core/push.ts
+++ b/app/remix-pwa-sw/core/push.ts
@@ -1,0 +1,19 @@
+declare let self: ServiceWorkerGlobalScope;
+
+export const handlePush = async (event: PushEvent) => {
+  const data = JSON.parse(event?.data!.text());
+  const title = data.title ? data.title : "Remix PWA";
+
+  const options = {
+    body: data.body ? data.body : "Notification Body Text",
+    icon: data.icon ? data.icon : "/icons/android-icon-192x192.png",
+    badge: data.badge ? data.badge : "/icons/android-icon-48x48.png",
+    dir: data.dir ? data.dir : "auto",
+    image: data.image ? data.image : undefined,
+    silent: data.silent ? data.silent : false,
+  };
+
+  self.registration.showNotification(title, {
+    ...options,
+  });
+};

--- a/app/remix-pwa-sw/fetch.ts
+++ b/app/remix-pwa-sw/fetch.ts
@@ -9,12 +9,17 @@ import type {
   NetworkOnlyOptions,
   Strategy,
 } from "./strategy";
-import { NetworkFirst } from "./strategy";
 
 export type MatchResponse = "loader" | "document" | "asset" | null;
-export type MatchRequest = (request: Request, { assetUrls }: { assetUrls: string[] }) => MatchResponse;
+export type MatchRequest = (
+  request: Request,
+  assetUrls: string[]
+) => MatchResponse;
 
-export const matchRequest: MatchRequest = (request: Request, { assetUrls = ["/build/", "/icons"] }): MatchResponse => {
+export const matchRequest: MatchRequest = (
+  request: Request,
+  assetUrls = ["/build/", "/icons"]
+): MatchResponse => {
   if (isAssetRequest(request, assetUrls)) {
     return "asset";
   } else if (isDocumentRequest(request)) {
@@ -25,30 +30,6 @@ export const matchRequest: MatchRequest = (request: Request, { assetUrls = ["/bu
     return null;
   }
 };
-
-// export const handleRequest = async (event: FetchEvent): Promise<Response> => {
-//   const { request } = event;
-
-//   if (request.method !== "GET") {
-//     // (ShafSpecs) todo: return an error or smthg like void.
-//     // by default, only handle GET requests
-//     // Devs can override this in their own service worker but
-//     // we are handling only `GET` requests.
-//   }
-
-//   const match = matchRequest(request);
-//   switch (match) {
-//     case "asset":
-//       return fetch(request);
-//     case "document":
-//       return fetch(request);
-//     case "loader":
-//       return fetch(request);
-//     case null:
-//     default:
-//       return fetch(request.clone());
-//   }
-// };
 
 export interface RequestHandlerOptions {
   cacheStrategy?: Strategy;
@@ -67,21 +48,10 @@ export interface AssetRequestHandlerParams extends RequestHandlerParams {
   assetUrls: string[];
 }
 
-export const handleLoaderRequest = ({
-  request,
-  options,
-}: RequestHandlerParams): Promise<Response> => {
-  const defaultStrategy = new NetworkFirst({
-    cacheName: "data-cache",
-    plugins: [],
-  });
-
-  const { cacheStrategy = defaultStrategy, matchOptions = {} } = options || {};
-
-  if (cacheStrategy === null) {
-    return fetch(request.clone());
-  }
-
+export const handleLoaderRequest = (
+  request: Request,
+  strategy: Strategy
+): Promise<Response> => {
   return fetch(request.clone());
 };
 

--- a/app/remix-pwa-sw/index.ts
+++ b/app/remix-pwa-sw/index.ts
@@ -1,11 +1,11 @@
-export {
-    matchRequest
-} from './fetch'
+export { matchRequest } from "./fetch";
 
 export {
-    isAssetRequest,
-    isDocumentRequest,
-    isLoaderRequest
-} from './core'
+  isAssetRequest,
+  isDocumentRequest,
+  isLoaderRequest,
+  handlePush,
+  handleMessage,
+} from "./core";
 
-export * from './strategy'
+export * from "./strategy";

--- a/app/remix-pwa-sw/react/index.ts
+++ b/app/remix-pwa-sw/react/index.ts
@@ -1,2 +1,2 @@
-export { useSWEffect } from './sw-hook'
-export { loadServiceWorker } from './loader'
+export { useSWEffect } from "./sw-hook";
+export { loadServiceWorker } from "./loader";

--- a/app/remix-pwa-sw/workbox/index.ts
+++ b/app/remix-pwa-sw/workbox/index.ts
@@ -1,0 +1,21 @@
+import { isAssetRequest, isDocumentRequest, isLoaderRequest } from "../core";
+
+export { remixLoaderPlugin } from "./plugin";
+
+type WBProps = {
+  url: URL;
+  request: Request;
+  event: Event;
+};
+
+export function matchAssetRequest({ request }: WBProps, assetUrls: string[]) {
+  return isAssetRequest(request, assetUrls);
+}
+
+export function matchDocumentRequest({ request }: WBProps) {
+  return isDocumentRequest(request);
+}
+
+export function matchLoaderRequest({ request }: WBProps) {
+  return isLoaderRequest(request);
+}

--- a/app/remix-pwa-sw/workbox/plugin.ts
+++ b/app/remix-pwa-sw/workbox/plugin.ts
@@ -1,0 +1,41 @@
+import {
+  CachedResponseWillBeUsedCallback,
+  HandlerDidErrorCallback,
+  CachedResponseWillBeUsedCallbackParam,
+  FetchDidSucceedCallback,
+  FetchDidSucceedCallbackParam,
+} from "workbox-core/types";
+
+/* Plugins */
+
+type RemixLoaderPlugin = {
+  cachedResponseWillBeUsed: CachedResponseWillBeUsedCallback;
+  handlerDidError: HandlerDidErrorCallback;
+  fetchDidSucceed: FetchDidSucceedCallback;
+};
+
+// Loader Plugin
+export const remixLoaderPlugin: RemixLoaderPlugin = {
+  fetchDidSucceed: async ({ response }: FetchDidSucceedCallbackParam) => {
+    // @ts-ignore
+    console.log("manifest", self.__remixManifest);
+    return response;
+  },
+  cachedResponseWillBeUsed: async ({
+    cachedResponse,
+  }: CachedResponseWillBeUsedCallbackParam) => {
+    cachedResponse?.headers.set("X-Remix-Worker", "yes");
+    return cachedResponse;
+  },
+  handlerDidError: async () => {
+    return new Response(JSON.stringify({ message: "Network Error" }), {
+      status: 500,
+      statusText: "Internal Server Error",
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        "X-Remix-Catch": "yes",
+        "X-Remix-Worker": "yes",
+      },
+    });
+  },
+};

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -7,15 +7,12 @@ import {
   Scripts,
   ScrollRestoration,
   useCatch,
-  useLocation,
-  useMatches,
 } from "@remix-run/react";
-import { useSWEffect } from "./useSW";
+import { useSWEffect } from "~/remix-pwa-sw/react";
 
 import type { LinksFunction, MetaFunction } from "@remix-run/node";
 
 import style from "./styles/index.css";
-import { useEffect } from "react";
 
 export const links: LinksFunction = () => {
   return [
@@ -30,46 +27,8 @@ export const meta: MetaFunction = () => ({
 });
 
 export default function App() {
-  const matches = useMatches();
-  const location = useLocation();
 
-  function isPromise(p: any): boolean {
-    if (typeof p === "object" && typeof p.then === "function") {
-      return true;
-    }
-
-    return false;
-  }
-
-  useSWEffect();
-  useEffect(() => {
-    const manifest = window.__remixManifest;
-    const match = matches.filter((route) => {
-      if (route.data) {
-        return (
-          Object.values(route.data!).filter((elem) => {
-            return isPromise(elem);
-          }).length === 0
-        );
-      }
-      return true;
-    })
-
-    let a = []
-
-    for (const match of matches) {
-      if (manifest.routes[match.id].hasLoader) {
-        const params = new URLSearchParams(location.search);
-        params.set("_data", match.id);
-        let search = params.toString();
-        search = search ? `?${search}` : "";
-        const url = location.pathname + search + location.hash;
-        a.push({ params, search, url })
-      }
-    }
-
-    console.log(a)
-  })
+useSWEffect()
 
 return (
   <html lang="en">

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,11 @@
         "isbot": "^3.6.5",
         "npm-run-all": "^4.1.5",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "workbox-background-sync": "^6.5.4",
+        "workbox-core": "^6.5.4",
+        "workbox-routing": "^6.5.4",
+        "workbox-strategies": "^6.5.4"
       },
       "devDependencies": {
         "@remix-run/dev": "^1.14.3",
@@ -2596,9 +2600,9 @@
       }
     },
     "node_modules/@remix-run/dev": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-1.14.3.tgz",
-      "integrity": "sha512-46mmwiA/k9YDkg0UrP90UB3azVVWRXw16NLHRSbZiaaYe8XgUkddEtBnH/nBp/IrVCtzUL3LObplUe5sFk5Z9Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-1.15.0.tgz",
+      "integrity": "sha512-BsE1GN6WM9PhN+agZi4TqUIuYzoHYZrufEdXLg3ZEYxWXqvtRKUNfhsYSDlEhrW+D5fyVQhJrs61wQ83sEXHLQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.18.6",
@@ -2612,8 +2616,8 @@
         "@babel/types": "^7.20.2",
         "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
         "@npmcli/package-json": "^2.0.0",
-        "@remix-run/server-runtime": "1.14.3",
-        "@vanilla-extract/integration": "^6.0.2",
+        "@remix-run/server-runtime": "1.15.0",
+        "@vanilla-extract/integration": "^6.2.0",
         "arg": "^5.0.1",
         "cacache": "^15.0.5",
         "chalk": "^4.1.2",
@@ -2626,14 +2630,15 @@
         "fast-glob": "3.2.11",
         "fs-extra": "^10.0.0",
         "get-port": "^5.1.1",
+        "glob-to-regexp": "0.4.1",
         "gunzip-maybe": "^1.4.2",
         "inquirer": "^8.2.1",
         "jsesc": "3.0.2",
-        "json5": "^2.2.1",
+        "json5": "^2.2.2",
         "lodash": "^4.17.21",
         "lodash.debounce": "^4.0.8",
         "lru-cache": "^7.14.1",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "node-fetch": "^2.6.7",
         "ora": "^5.4.1",
         "postcss": "^8.4.19",
@@ -2661,7 +2666,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@remix-run/serve": "^1.14.3"
+        "@remix-run/serve": "^1.15.0"
       },
       "peerDependenciesMeta": {
         "@remix-run/serve": {
@@ -2670,9 +2675,9 @@
       }
     },
     "node_modules/@remix-run/eslint-config": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/eslint-config/-/eslint-config-1.14.3.tgz",
-      "integrity": "sha512-Yy4PYSvAehj31LmkDA+lS5yCPL1lR9O04gMIo0xwHT2o59pF4QU54lEAvJJH+9MI0byZUI/v9DoGz1oGIb44IA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/eslint-config/-/eslint-config-1.15.0.tgz",
+      "integrity": "sha512-nwCPK/4anLMDWJnBsrWL9Wfcy2eRDlKjGWZeYeozDpJnH9iG1vA5aow0OmcpblwgvAwcgSC8Gdb7P5uK4Xy5/Q==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.19.1",
@@ -2698,7 +2703,7 @@
       "peerDependencies": {
         "eslint": "^8.0.0",
         "react": "^17.0.0 || ^18.0.0",
-        "typescript": "^4.0.0"
+        "typescript": "^4.0.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2707,11 +2712,11 @@
       }
     },
     "node_modules/@remix-run/express": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-1.14.3.tgz",
-      "integrity": "sha512-v3TT+zBFSnOiVTHNiLp5A783UVYyZYbePxmPhvoe9JwHCmzVDA9mfyxYgDl/8NPDtYS+dAPU7mQ+aE1M5MXc7g==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-1.15.0.tgz",
+      "integrity": "sha512-mvDZB03W6NqbtyVpeiJfmGQY1L7CX+KEfSIV/kNgyK+gAMAWhsioC/Vjlo4IFY3NvOD0rh9mxuC+/IPT6Al3uw==",
       "dependencies": {
-        "@remix-run/node": "1.14.3"
+        "@remix-run/node": "1.15.0"
       },
       "engines": {
         "node": ">=14"
@@ -2721,11 +2726,11 @@
       }
     },
     "node_modules/@remix-run/node": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-1.14.3.tgz",
-      "integrity": "sha512-Mq0wUtgJtGwMQEBr/8p9XpdPBm7N+lby5CEbW6IKV59UC9N3VMGY3snfrsphBCq3sNZfbhIpaDdu2W+8EoqfnQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-1.15.0.tgz",
+      "integrity": "sha512-CS0p8T6A2KvMoAW5zzLA/BtNNCsv34A5RJoouJvXK9/o6MriAQ/YSugg6ldS5mec49neSep+CGeL1RS6tL+3NQ==",
       "dependencies": {
-        "@remix-run/server-runtime": "1.14.3",
+        "@remix-run/server-runtime": "1.15.0",
         "@remix-run/web-fetch": "^4.3.2",
         "@remix-run/web-file": "^3.0.2",
         "@remix-run/web-stream": "^1.0.3",
@@ -2740,12 +2745,12 @@
       }
     },
     "node_modules/@remix-run/react": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-1.14.3.tgz",
-      "integrity": "sha512-dvwIx+9ZdE/9LHe8Rjos9gEOdQFLvC0dojCnKlsUIwfGhyjKE4wOHfqS9mZcmKFCvOFDakcZDallLNGaj0mEYg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-1.15.0.tgz",
+      "integrity": "sha512-S0RuIeHvQTqryCZ3KVl8EsIWCqL6/ky1/kmDpN2n5Pdjew2BLC6DX7OdrY1ZQjbzOMHAROsZlyaSSVXCItunag==",
       "dependencies": {
-        "@remix-run/router": "1.3.3",
-        "react-router-dom": "6.8.2",
+        "@remix-run/router": "1.5.0",
+        "react-router-dom": "6.10.0",
         "use-sync-external-store": "1.2.0"
       },
       "engines": {
@@ -2757,19 +2762,19 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.3.tgz",
-      "integrity": "sha512-YRHie1yQEj0kqqCTCJEfHqYSSNlZQ696QJG+MMiW4mxSl9I0ojz/eRhJS4fs88Z5i6D1SmoF9d3K99/QOhI8/w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.5.0.tgz",
+      "integrity": "sha512-bkUDCp8o1MvFO+qxkODcbhSqRa6P2GXgrGZVpt0dCXNW2HCSCqYI0ZoAqEOSAjRWmmlKcYgFvN4B4S+zo/f8kg==",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@remix-run/serve": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-1.14.3.tgz",
-      "integrity": "sha512-5So5+PtAaYZq3hc45snkCKIOh51Z45WvhHpRgB0ZsOuhUf6p9UAY9LQk7GRNvkcqL9LChE3LQ9O4gPqnUiZgpA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-1.15.0.tgz",
+      "integrity": "sha512-j06vKhxtLSR3JpkcoBMPb1EeM6QrbbuTdDh4m0eY/D4QgUzba4ws6r3OzEGc5FMe5xSULO0YVd2QWlyqBlMIWQ==",
       "dependencies": {
-        "@remix-run/express": "1.14.3",
+        "@remix-run/express": "1.15.0",
         "compression": "^1.7.4",
         "express": "^4.17.1",
         "morgan": "^1.10.0"
@@ -2782,11 +2787,11 @@
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.14.3.tgz",
-      "integrity": "sha512-qh8sxfLj/XW1u6rluN7yIgbvMCoKrVacYGUiPM7g0VHk8h8MlZGAIUfsWM45Poxo3X0uLhNuqqxMaPWldKawIQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.15.0.tgz",
+      "integrity": "sha512-DL9xjHfYYrEcOq5VbhYtrjJUWo/nFQAT7Y+Np/oC55HokyU6cb2jGhl52nx96aAxKwaFCse5N90GeodFsRzX7w==",
       "dependencies": {
-        "@remix-run/router": "1.3.3",
+        "@remix-run/router": "1.5.0",
         "@types/cookie": "^0.4.0",
         "@types/react": "^18.0.15",
         "@web3-storage/multipart-parser": "^1.0.0",
@@ -6975,6 +6980,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true
+    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -7322,6 +7333,11 @@
       "peerDependencies": {
         "postcss": "^8.1.0"
       }
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -10677,11 +10693,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.8.2.tgz",
-      "integrity": "sha512-lF7S0UmXI5Pd8bmHvMdPKI4u4S5McxmHnzJhrYi9ZQ6wE+DA8JN5BzVC5EEBuduWWDaiJ8u6YhVOCmThBli+rw==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.10.0.tgz",
+      "integrity": "sha512-Nrg0BWpQqrC3ZFFkyewrflCud9dio9ME3ojHCF/WLsprJVzkq3q3UeEhMCAW1dobjeGbWgjNn/PVF6m46ANxXQ==",
       "dependencies": {
-        "@remix-run/router": "1.3.3"
+        "@remix-run/router": "1.5.0"
       },
       "engines": {
         "node": ">=14"
@@ -10691,12 +10707,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.8.2.tgz",
-      "integrity": "sha512-N/oAF1Shd7g4tWy+75IIufCGsHBqT74tnzHQhbiUTYILYF0Blk65cg+HPZqwC+6SqEyx033nKqU7by38v3lBZg==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.10.0.tgz",
+      "integrity": "sha512-E5dfxRPuXKJqzwSe/qGcqdwa18QiWC6f3H3cWXM24qj4N0/beCIf/CWTipop2xm7mR0RCS99NnaqPNjHtrAzCg==",
       "dependencies": {
-        "@remix-run/router": "1.3.3",
-        "react-router": "6.8.2"
+        "@remix-run/router": "1.5.0",
+        "react-router": "6.10.0"
       },
       "engines": {
         "node": ">=14"
@@ -13085,6 +13101,36 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/workbox-background-sync": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-6.5.4.tgz",
+      "integrity": "sha512-0r4INQZMyPky/lj4Ou98qxcThrETucOde+7mRGJl13MPJugQNKeZQOdIJe/1AchOP23cTqHcN/YVpD6r8E6I8g==",
+      "dependencies": {
+        "idb": "^7.0.1",
+        "workbox-core": "6.5.4"
+      }
+    },
+    "node_modules/workbox-core": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-6.5.4.tgz",
+      "integrity": "sha512-OXYb+m9wZm8GrORlV2vBbE5EC1FKu71GGp0H4rjmxmF4/HLbMCoTFws87M3dFwgpmg0v00K++PImpNQ6J5NQ6Q=="
+    },
+    "node_modules/workbox-routing": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-6.5.4.tgz",
+      "integrity": "sha512-apQswLsbrrOsBUWtr9Lf80F+P1sHnQdYodRo32SjiByYi36IDyL2r7BH1lJtFX8fwNHDa1QOVY74WKLLS6o5Pg==",
+      "dependencies": {
+        "workbox-core": "6.5.4"
+      }
+    },
+    "node_modules/workbox-strategies": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-6.5.4.tgz",
+      "integrity": "sha512-DEtsxhx0LIYWkJBTQolRxG4EI0setTJkqR4m7r4YpBdxtWJH1Mbg01Cj8ZjNOO8etqfA3IZaOPHUxCs8cBsKLw==",
+      "dependencies": {
+        "workbox-core": "6.5.4"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "remix build",
     "dev": "run-p dev:*",
     "dev:remix": "remix dev",
-    "dev:worker": "esbuild ./app/entry.worker.ts --outfile=./public/entry.worker.js --bundle --format=esm --define:process.env.NODE_ENV='\"development\"' --watch",
+    "dev:worker": "esbuild ./app/entry.workbox.ts --outfile=./public/entry.worker.js --bundle --format=esm --define:process.env.NODE_ENV='\"development\"' --watch",
     "start": "remix-serve build",
     "typecheck": "tsc"
   },
@@ -16,7 +16,11 @@
     "isbot": "^3.6.5",
     "npm-run-all": "^4.1.5",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "workbox-background-sync": "^6.5.4",
+    "workbox-core": "^6.5.4",
+    "workbox-routing": "^6.5.4",
+    "workbox-strategies": "^6.5.4"
   },
   "devDependencies": {
     "@remix-run/dev": "^1.14.3",


### PR DESCRIPTION
Runtime caching for vanilla-sw and workbox is working now. Pages are available offline and `handlePush` and `handleMessage` are doing their task. Although there is a problem with the weird behavior of the catch-boundary but looking at the requirement of this feature this can be ignored for now and needs special attention.

As i have proposed three APIs for handling requests but now looks like we don't need them either.
```ts
const assetHandler= new CacheFirst({ cacheName: Asset }) 
const pageHandler= new NetworkFirst({ cacheName: Page }) 
const dataHandler= new NetworkFirst({ cacheName: Data, isLoader: true }) // We need to identify the loader requests to return a special response when no resource is found. 

async function handleFetch(event) { 
  const match = matchRequest(event.request, assetUrl) 
  switch(match) { 
    case 'asset': 
      return assetHandler(event.request)
    case 'document':
      return documentHandler(event.request) 
    case 'data': 
      return dataHandler(event.request) 
    default:
     return fetch(event.request.clone())
  } 
}
```

Our both SW files are looking tiny, neat, and clean.