### PR TITLE
fix pre-caching for both vanilla-sw and workbox

### DIFF
--- a/app/precache.workbox.ts
+++ b/app/precache.workbox.ts
@@ -1,286 +1,112 @@
 /// <reference lib="WebWorker" />
 
-import { json } from "@remix-run/server-runtime";
-import type { AssetsManifest } from "@remix-run/react/dist/entry";
-import type { EntryRoute } from "@remix-run/react/dist/routes";
+import { registerRoute, setDefaultHandler } from "workbox-routing";
+import { CacheFirst, NetworkFirst } from "workbox-strategies";
+import { BackgroundSyncPlugin } from "workbox-background-sync";
+
+import { 
+  matchAssetRequest, 
+  matchDocumentRequest, 
+  matchLoaderRequest, 
+  remixLoaderPlugin 
+} from '~/remix-pwa-sw/workbox'
+
+import { 
+  handlePush,
+  handleSyncRemixManifest
+} from '~/remix-pwa-sw'
 
 declare let self: ServiceWorkerGlobalScope;
 
+const PAGES = "page-cache-v1";
+const DATA = "data-cache-v1";
+const ASSETS = "assets-cache-v1";
+const StaticAssets = ['/build/', '/icons/']
+
 function debug(...messages: any[]) {
-  if (process.env.NODE_ENV === "development") {
+  if (process.env.NODE_ENV !== "production") {
     console.debug(...messages);
   }
 }
 
-async function handleInstall(event: ExtendableEvent) {
-  debug("Service worker installed");
-}
+// (dev-afzalansari) - TODO: This plugin is just for testing workbox in development
+// remove this plugin while creating a template from it.
+const backgroundSyncPlugin = new BackgroundSyncPlugin("loaderQueue", {
+  maxRetentionTime: 60 * 24,
+  onSync: async ({ queue }) => {
+    let entry;
+    while ((entry = await queue.shiftRequest())) {
+      try {
+        const replayedResponse = await fetch(entry.request.clone());
+        const dataCache = await caches.open(DATA);
+        await dataCache.put(entry.request, replayedResponse.clone());
 
-async function handleActivate(event: ExtendableEvent) {
-  debug("Service worker activated");
-}
+        debug(
+          `Request for '${entry.request.url}' ` +
+            `has been replayed in queue '${queue.name}'`
+        );
+      } catch (error) {
+        await queue.unshiftRequest(entry);
 
-const ASSET_CACHE = "asset-cache";
-const DATA_CACHE = "data-cache";
-const DOCUMENT_CACHE = "document-cache";
-const STATIC_ASSETS = ["/build/", "/icons/"];
-
-async function handleSyncRemixManifest(event: ExtendableMessageEvent) {
-  console.debug("sync manifest");
-  const cachePromises: Map<string, Promise<void>> = new Map();
-  const [dataCache, documentCache, assetCache] = await Promise.all([
-    caches.open(DATA_CACHE),
-    caches.open(DOCUMENT_CACHE),
-    caches.open(ASSET_CACHE),
-  ]);
-  const manifest: AssetsManifest = event.data.manifest;
-  const routes = Object.values(manifest.routes);
-
-  for (const route of routes) {
-    if (route.id.includes("$")) {
-      console.debug("parametrized route", route.id);
-      continue;
-    }
-
-    cacheRoute(route);
-  }
-
-  await Promise.all(cachePromises.values());
-
-  function cacheRoute(route: EntryRoute) {
-    const pathname = getPathname(route);
-    if (route.hasLoader) {
-      cacheLoaderData(route);
-    }
-
-    if (route.module) {
-      cachePromises.set(route.module, cacheAsset(route.module));
-    }
-
-    if (route.imports) {
-      for (const assetUrl of route.imports) {
-        debug(route.index, route.parentId, route.imports, route.module);
-        if (cachePromises.has(assetUrl)) {
-          continue;
-        }
-
-        cachePromises.set(assetUrl, cacheAsset(assetUrl));
+        debug(
+          `Request for '${entry.request.url}' ` +
+            `failed to replay, putting it back in queue '${queue.name}'`
+        );
       }
     }
-
-    cachePromises.set(
-      pathname,
-      documentCache.add(pathname).catch((error) => {
-        console.debug(`Failed to cache document ${pathname}:`, error);
-      })
+    debug(
+      `All requests in queue '${queue.name}' have successfully ` +
+        `replayed; the queue is now empty!`
     );
-  }
+  },
+});
+//////////////////////////////
 
-  function cacheLoaderData(route: EntryRoute) {
-    const pathname = getPathname(route);
-    const params = new URLSearchParams({ _data: route.id });
-    const search = `?${params.toString()}`;
-    const url = pathname + search;
-    if (!cachePromises.has(url)) {
-      console.debug("Caching data for", url);
-      cachePromises.set(
-        url,
-        dataCache.add(url).catch((error) => {
-          console.debug(`Failed to cache data for ${url}:`, error);
-        })
-      );
-    }
-  }
 
-  async function cacheAsset(assetUrl: string) {
-    if (await assetCache.match(assetUrl)) {
-      return;
-    }
+// Assets
+registerRoute((event) => matchAssetRequest(event, StaticAssets),
+  new CacheFirst({
+    cacheName: ASSETS,
+  })
+);
 
-    console.debug("Caching asset", assetUrl);
-    return assetCache.add(assetUrl).catch((error) => {
-      console.debug(`Failed to cache asset ${assetUrl}:`, error);
-    });
-  }
+// Loaders
+registerRoute(
+  matchLoaderRequest,
+  new NetworkFirst({
+    cacheName: DATA,
+    plugins: [backgroundSyncPlugin, remixLoaderPlugin],
+  })
+);
 
-  function getPathname(route: EntryRoute) {
-    let pathname = "";
-    if (route.path && route.path.length > 0) {
-      pathname = "/" + route.path;
-    }
-    if (route.parentId) {
-      const parentPath = getPathname(manifest.routes[route.parentId]);
-      if (parentPath) {
-        pathname = parentPath + pathname;
-      }
-    }
-    return pathname;
-  }
-}
+// Documents
+registerRoute(
+  matchDocumentRequest,
+  new NetworkFirst({
+    cacheName: PAGES,
+  })
+);
 
-async function handleFetch(event: FetchEvent): Promise<Response> {
-  const url = new URL(event.request.url);
-
-  if (isAssetRequest(event.request)) {
-    const cached = await caches.match(event.request, {
-      cacheName: ASSET_CACHE,
-      ignoreVary: true,
-      ignoreSearch: true,
-    });
-    if (cached) {
-      debug("Serving asset from cache", url.pathname);
-      return cached;
-    }
-
-    debug("Serving asset from network", url.pathname);
-    const response = await fetch(event.request);
-    if (response.status === 200) {
-      const cache = await caches.open(ASSET_CACHE);
-      await cache.put(event.request, response.clone());
-    }
-    return response;
-  }
-
-  if (isLoaderRequest(event.request)) {
-    try {
-      debug("Serving data from network", url.pathname + url.search);
-      const response = await fetch(event.request.clone());
-      const cache = await caches.open(DATA_CACHE);
-      await cache.put(event.request, response.clone());
-      return response;
-    } catch (error) {
-      debug(
-        "Serving data from network failed, falling back to cache",
-        url.pathname + url.search
-      );
-      const response = await caches.match(event.request);
-      if (response) {
-        response.headers.set("X-Remix-Worker", "yes");
-        return response;
-      }
-
-      return json(
-        { message: "Network Error" },
-        {
-          status: 500,
-          headers: { "X-Remix-Catch": "yes", "X-Remix-Worker": "yes" },
-        }
-      );
-    }
-  }
-
-  if (isDocumentGetRequest(event.request)) {
-    const url = new URL(event.request.url);
-    console.debug("Serving document from network", url.pathname);
-    return caches.open(DOCUMENT_CACHE).then((cache) =>
-      fetch(event.request.clone())
-        .then((response) => {
-          cache.put(event.request, response.clone());
-          return response;
-        })
-        .catch(async (error) => {
-          console.debug(
-            "Serving document from network failed, falling back to cache",
-            url.pathname
-          );
-          const response = await caches.match(event.request);
-          if (!response) {
-            throw error;
-          }
-          return response;
-        })
-    );
-  }
-
-  return fetch(event.request.clone());
-}
-
-const handlePush = (event: PushEvent) => {
-  const data = JSON.parse(event?.data!.text());
-  const title = data.title ? data.title : "Remix PWA";
-
-  const options = {
-    body: data.body ? data.body : "Notification Body Text",
-    icon: data.icon ? data.icon : "/icons/android-icon-192x192.png",
-    badge: data.badge ? data.badge : "/icons/android-icon-48x48.png",
-    dir: data.dir ? data.dir : "auto",
-    image: data.image ? data.image : undefined,
-    silent: data.silent ? data.silent : false,
-  };
-
-  self.registration.showNotification(title, {
-    ...options,
-  });
-};
-
-function isMethod(request: Request, methods: string[]) {
-  return methods.includes(request.method.toLowerCase());
-}
-
-function isAssetRequest(request: Request) {
-  return (
-    isMethod(request, ["get"]) &&
-    STATIC_ASSETS.some((publicPath) => request.url.includes(publicPath))
-  );
-}
-
-function isLoaderRequest(request: Request) {
-  const url = new URL(request.url);
-  return isMethod(request, ["get"]) && url.searchParams.get("_data");
-}
-
-function isDocumentGetRequest(request: Request) {
-  return isMethod(request, ["get"]) && request.mode === "navigate";
-}
+setDefaultHandler(({ request }) => {
+  return fetch(request.clone());
+});
 
 self.addEventListener("install", (event) => {
-  event.waitUntil(handleInstall(event).then(() => self.skipWaiting()));
+  event.waitUntil(self.skipWaiting());
 });
 
 self.addEventListener("activate", (event) => {
-  event.waitUntil(handleActivate(event).then(() => self.clients.claim()));
-});
-
-self.addEventListener("message", (event) => {
-  // event.waitUntil(handleMessage(event));
-  event.waitUntil(handleSyncRemixManifest(event));
+  event.waitUntil(self.clients.claim());
 });
 
 self.addEventListener("push", (event) => {
-  // self.clients.matchAll().then(function (c) {
-  // if (c.length === 0) {
   event.waitUntil(handlePush(event));
-  // } else {
-  //   console.log("Application is already open!");
-  // }
-  // });
 });
 
-self.addEventListener("fetch", (event) => {
-  event.respondWith(
-    (async () => {
-      const result = {} as
-        | { error: unknown; response: Response }
-        | { error: undefined; response: Response };
-      try {
-        result.response = await handleFetch(event);
-      } catch (error) {
-        result.error = error;
-      }
-
-      return appHandleFetch(event, result);
-    })()
-  );
+self.addEventListener("message", (event) => {
+  event.waitUntil(handleSyncRemixManifest(event, { 
+    dataCache: DATA, 
+    documentCache: PAGES,
+    assetCache: ASSETS
+  }));
 });
-
-async function appHandleFetch(
-  event: FetchEvent,
-  {
-    error,
-    response,
-  }:
-    | { error: unknown; response: Response }
-    | { error: undefined; response: Response }
-): Promise<Response> {
-  return response;
-}

--- a/app/precache.worker.ts
+++ b/app/precache.worker.ts
@@ -1,287 +1,61 @@
 /// <reference lib="WebWorker" />
 
-import { json } from "@remix-run/server-runtime";
-import type { AssetsManifest } from "@remix-run/react/dist/entry";
-import type { EntryRoute } from "@remix-run/react/dist/routes";
+import {
+  matchRequest,
+  handlePush,
+  CacheFirst,
+  NetworkFirst,
+  handleSyncRemixManifest
+} from "~/remix-pwa-sw";
 
-export type {};
 declare let self: ServiceWorkerGlobalScope;
 
-function debug(...messages: any[]) {
-  if (process.env.NODE_ENV === "development") {
-    console.debug(...messages);
+const PAGES = "page-cache";
+const DATA = "data-cache";
+const ASSETS = "assets-cache";
+const StaticAssets = ["/build/", "/icons/"];
+
+const assetHandler = new CacheFirst({ cacheName: ASSETS });
+const pageHandler = new NetworkFirst({ cacheName: PAGES });
+const dataHandler = new NetworkFirst({ cacheName: DATA, isLoader: true });
+
+const fetchHandler = async (event: FetchEvent): Promise<Response> => {
+  const { request } = event;
+  const match = matchRequest(request, StaticAssets);
+
+  switch (match) {
+    case "asset":
+      return assetHandler.handle(request);
+    case "document":
+      return pageHandler.handle(request);
+    case "loader":
+      return dataHandler.handle(request);
+    default:
+      return fetch(request.clone());
   }
-}
-
-async function handleInstall(event: ExtendableEvent) {
-  debug("Service worker installed");
-}
-
-async function handleActivate(event: ExtendableEvent) {
-  debug("Service worker activated");
-}
-
-const ASSET_CACHE = "asset-cache";
-const DATA_CACHE = "data-cache";
-const DOCUMENT_CACHE = "document-cache";
-const STATIC_ASSETS = ["/build/", "/icons/"];
-
-async function handleSyncRemixManifest(event: ExtendableMessageEvent) {
-  console.debug("sync manifest");
-  const cachePromises: Map<string, Promise<void>> = new Map();
-  const [dataCache, documentCache, assetCache] = await Promise.all([
-    caches.open(DATA_CACHE),
-    caches.open(DOCUMENT_CACHE),
-    caches.open(ASSET_CACHE),
-  ]);
-  const manifest: AssetsManifest = event.data.manifest;
-  const routes = Object.values(manifest.routes);
-
-  for (const route of routes) {
-    if (route.id.includes("$")) {
-      console.debug("parametrized route", route.id);
-      continue;
-    }
-
-    cacheRoute(route);
-  }
-
-  await Promise.all(cachePromises.values());
-
-  function cacheRoute(route: EntryRoute) {
-    const pathname = getPathname(route);
-    if (route.hasLoader) {
-      cacheLoaderData(route);
-    }
-
-    if (route.module) {
-      cachePromises.set(route.module, cacheAsset(route.module));
-    }
-
-    if (route.imports) {
-      for (const assetUrl of route.imports) {
-        debug(route.index, route.parentId, route.imports, route.module);
-        if (cachePromises.has(assetUrl)) {
-          continue;
-        }
-
-        cachePromises.set(assetUrl, cacheAsset(assetUrl));
-      }
-    }
-
-    cachePromises.set(
-      pathname,
-      documentCache.add(pathname).catch((error) => {
-        console.debug(`Failed to cache document ${pathname}:`, error);
-      })
-    );
-  }
-
-  function cacheLoaderData(route: EntryRoute) {
-    const pathname = getPathname(route);
-    const params = new URLSearchParams({ _data: route.id });
-    const search = `?${params.toString()}`;
-    const url = pathname + search;
-    if (!cachePromises.has(url)) {
-      console.debug("Caching data for", url);
-      cachePromises.set(
-        url,
-        dataCache.add(url).catch((error) => {
-          console.debug(`Failed to cache data for ${url}:`, error);
-        })
-      );
-    }
-  }
-
-  async function cacheAsset(assetUrl: string) {
-    if (await assetCache.match(assetUrl)) {
-      return;
-    }
-
-    console.debug("Caching asset", assetUrl);
-    return assetCache.add(assetUrl).catch((error) => {
-      console.debug(`Failed to cache asset ${assetUrl}:`, error);
-    });
-  }
-
-  function getPathname(route: EntryRoute) {
-    let pathname = "";
-    if (route.path && route.path.length > 0) {
-      pathname = "/" + route.path;
-    }
-    if (route.parentId) {
-      const parentPath = getPathname(manifest.routes[route.parentId]);
-      if (parentPath) {
-        pathname = parentPath + pathname;
-      }
-    }
-    return pathname;
-  }
-}
-
-async function handleFetch(event: FetchEvent): Promise<Response> {
-  const url = new URL(event.request.url);
-
-  if (isAssetRequest(event.request)) {
-    const cached = await caches.match(event.request, {
-      cacheName: ASSET_CACHE,
-      ignoreVary: true,
-      ignoreSearch: true,
-    });
-    if (cached) {
-      debug("Serving asset from cache", url.pathname);
-      return cached;
-    }
-
-    debug("Serving asset from network", url.pathname);
-    const response = await fetch(event.request);
-    if (response.status === 200) {
-      const cache = await caches.open(ASSET_CACHE);
-      await cache.put(event.request, response.clone());
-    }
-    return response;
-  }
-
-  if (isLoaderRequest(event.request)) {
-    try {
-      debug("Serving data from network", url.pathname + url.search);
-      const response = await fetch(event.request.clone());
-      const cache = await caches.open(DATA_CACHE);
-      await cache.put(event.request, response.clone());
-      return response;
-    } catch (error) {
-      debug(
-        "Serving data from network failed, falling back to cache",
-        url.pathname + url.search
-      );
-      const response = await caches.match(event.request);
-      if (response) {
-        response.headers.set("X-Remix-Worker", "yes");
-        return response;
-      }
-
-      return json(
-        { message: "Network Error" },
-        {
-          status: 500,
-          headers: { "X-Remix-Catch": "yes", "X-Remix-Worker": "yes" },
-        }
-      );
-    }
-  }
-
-  if (isDocumentGetRequest(event.request)) {
-    const url = new URL(event.request.url);
-    console.debug("Serving document from network", url.pathname);
-    return caches.open(DOCUMENT_CACHE).then((cache) =>
-      fetch(event.request.clone())
-        .then((response) => {
-          cache.put(event.request, response.clone());
-          return response;
-        })
-        .catch(async (error) => {
-          console.debug(
-            "Serving document from network failed, falling back to cache",
-            url.pathname
-          );
-          const response = await caches.match(event.request);
-          if (!response) {
-            throw error;
-          }
-          return response;
-        })
-    );
-  }
-
-  return fetch(event.request.clone());
-}
-
-const handlePush = (event: PushEvent) => {
-  const data = JSON.parse(event?.data!.text());
-  const title = data.title ? data.title : "Remix PWA";
-
-  const options = {
-    body: data.body ? data.body : "Notification Body Text",
-    icon: data.icon ? data.icon : "/icons/android-icon-192x192.png",
-    badge: data.badge ? data.badge : "/icons/android-icon-48x48.png",
-    dir: data.dir ? data.dir : "auto",
-    image: data.image ? data.image : undefined,
-    silent: data.silent ? data.silent : false,
-  };
-
-  self.registration.showNotification(title, {
-    ...options,
-  });
 };
 
-function isMethod(request: Request, methods: string[]) {
-  return methods.includes(request.method.toLowerCase());
-}
-
-function isAssetRequest(request: Request) {
-  return (
-    isMethod(request, ["get"]) &&
-    STATIC_ASSETS.some((publicPath) => request.url.includes(publicPath))
-  );
-}
-
-function isLoaderRequest(request: Request) {
-  const url = new URL(request.url);
-  return isMethod(request, ["get"]) && url.searchParams.get("_data");
-}
-
-function isDocumentGetRequest(request: Request) {
-  return isMethod(request, ["get"]) && request.mode === "navigate";
-}
 
 self.addEventListener("install", (event) => {
-  event.waitUntil(handleInstall(event).then(() => self.skipWaiting()));
+  event.waitUntil(self.skipWaiting());
 });
 
 self.addEventListener("activate", (event) => {
-  event.waitUntil(handleActivate(event).then(() => self.clients.claim()));
+  event.waitUntil(self.clients.claim());
 });
 
 self.addEventListener("message", (event) => {
-  // event.waitUntil(handleMessage(event));
-  event.waitUntil(handleSyncRemixManifest(event));
+  event.waitUntil(handleSyncRemixManifest(event, {
+    dataCache: DATA,
+    assetCache: ASSETS,
+    documentCache: PAGES
+  }));
 });
 
 self.addEventListener("push", (event) => {
-  // self.clients.matchAll().then(function (c) {
-  // if (c.length === 0) {
   event.waitUntil(handlePush(event));
-  // } else {
-  //   console.log("Application is already open!");
-  // }
-  // });
 });
 
 self.addEventListener("fetch", (event) => {
-  event.respondWith(
-    (async () => {
-      const result = {} as
-        | { error: unknown; response: Response }
-        | { error: undefined; response: Response };
-      try {
-        result.response = await handleFetch(event);
-      } catch (error) {
-        result.error = error;
-      }
-
-      return appHandleFetch(event, result);
-    })()
-  );
+  event.respondWith(fetchHandler(event));
 });
-
-async function appHandleFetch(
-  event: FetchEvent,
-  {
-    error,
-    response,
-  }:
-    | { error: unknown; response: Response }
-    | { error: undefined; response: Response }
-): Promise<Response> {
-  return response;
-}

--- a/app/remix-pwa-sw/core/index.ts
+++ b/app/remix-pwa-sw/core/index.ts
@@ -1,6 +1,6 @@
 export { logger } from "./logger";
 export { handlePush } from "./push";
-export { handleMessage } from "./message";
+export { handleMessage, handleSyncRemixManifest } from "./message";
 
 export function isMethod(request: Request, methods: string[]): boolean {
   return methods.includes(request.method.toLowerCase());

--- a/app/remix-pwa-sw/core/message.ts
+++ b/app/remix-pwa-sw/core/message.ts
@@ -1,3 +1,6 @@
+import type { AssetsManifest } from "@remix-run/react/dist/entry";
+import type { EntryRoute } from "@remix-run/react/dist/routes";
+
 export async function handleMessage(
   event: ExtendableMessageEvent,
   {
@@ -53,4 +56,108 @@ export async function handleMessage(
   }
 
   await Promise.all(cachePromises.values());
+}
+
+
+export async function handleSyncRemixManifest(event: ExtendableMessageEvent, {
+  dataCache,
+  documentCache,
+  assetCache
+}: {
+  dataCache: string;
+  documentCache: string;
+  assetCache: string;
+}) {
+  console.debug("sync manifest");
+  const cachePromises: Map<string, Promise<void>> = new Map();
+  const [DataCache, DocumentCache, AssetCache] = await Promise.all([
+    caches.open(dataCache),
+    caches.open(documentCache),
+    caches.open(assetCache),
+  ]);
+  const manifest: AssetsManifest = event.data.manifest;
+  const routes = Object.values(manifest.routes);
+
+  for (const route of routes) {
+    if (route.id.includes("$")) {
+      console.debug("parametrized route", route.id);
+      continue;
+    }
+
+    cacheRoute(route);
+  }
+
+  await Promise.all(cachePromises.values());
+
+  function cacheRoute(route: EntryRoute) {
+    const pathname = getPathname(route);
+    if (route.hasLoader) {
+      cacheLoaderData(route);
+    }
+
+    if (route.module) {
+      cachePromises.set(route.module, cacheAsset(route.module));
+    }
+
+    if (route.imports) {
+      for (const assetUrl of route.imports) {
+        // debug(route.index, route.parentId, route.imports, route.module);
+        if (cachePromises.has(assetUrl)) {
+          continue;
+        }
+
+        cachePromises.set(assetUrl, cacheAsset(assetUrl));
+      }
+    }
+
+    cachePromises.set(
+      pathname,
+      DocumentCache.add(pathname).catch((error) => {
+        console.debug(`Failed to cache document ${pathname}:`, error);
+      })
+    );
+  }
+
+  function cacheLoaderData(route: EntryRoute) {
+    const pathname = getPathname(route);
+    const params = new URLSearchParams({ _data: route.id });
+    const search = `?${params.toString()}`;
+    const url = pathname + search;
+    if (!cachePromises.has(url)) {
+      console.debug("Caching data for", url);
+      cachePromises.set(
+        url,
+        DataCache.add(url).catch((error) => {
+          console.debug(`Failed to cache data for ${url}:`, error);
+        })
+      );
+    }
+  }
+
+  async function cacheAsset(assetUrl: string) {
+    if (await AssetCache.match(assetUrl)) {
+      return;
+    }
+
+    console.debug("Caching asset", assetUrl);
+    return AssetCache.add(assetUrl).catch((error) => {
+      console.debug(`Failed to cache asset ${assetUrl}:`, error);
+    });
+  }
+
+  function getPathname(route: EntryRoute) {
+    if(route.index) return "/"
+
+    let pathname = "";
+    if (route.path && route.path.length > 0) {
+      pathname = "/" + route.path;
+    }
+    if (route.parentId) {
+      const parentPath = getPathname(manifest.routes[route.parentId]);
+      if (parentPath) {
+        pathname = parentPath + pathname;
+      }
+    }
+    return pathname;
+  }
 }

--- a/app/remix-pwa-sw/index.ts
+++ b/app/remix-pwa-sw/index.ts
@@ -6,6 +6,7 @@ export {
   isLoaderRequest,
   handlePush,
   handleMessage,
+  handleSyncRemixManifest
 } from "./core";
 
 export * from "./strategy";

--- a/app/remix-pwa-sw/strategy.ts
+++ b/app/remix-pwa-sw/strategy.ts
@@ -115,8 +115,6 @@ export class NetworkFirst extends Strategy {
         ignoreSearch: this.matchOptions?.ignoreSearch || false,
       });
 
-      console.log(cachedResponse);
-
       if (cachedResponse) {
         this.isLoader && cachedResponse.headers.set("X-Remix-Worker", "yes");
         return cachedResponse;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "remix build",
     "dev": "run-p dev:*",
     "dev:remix": "remix dev",
-    "dev:worker": "esbuild ./app/entry.workbox.ts --outfile=./public/entry.worker.js --bundle --format=esm --define:process.env.NODE_ENV='\"development\"' --watch",
+    "dev:worker": "esbuild ./app/precache.workbox.ts --outfile=./public/entry.worker.js --bundle --format=esm --define:process.env.NODE_ENV='\"development\"' --watch",
     "start": "remix-serve build",
     "typecheck": "tsc"
   },


### PR DESCRIPTION
All four service workers are doing their job now according to my testing. They are small, clear, and extendable. 

I have tried to keep APIs simple as I can but they can be improved if needed but before moving these files into the original package we need to recheck API names and make them more descriptive.

The catch-boundary behavior in `precache.worker` and `precache.workbox` is as expected.